### PR TITLE
Fix signup endpoint mapping

### DIFF
--- a/src/main/java/com/example/demo/controller/ContentController.java
+++ b/src/main/java/com/example/demo/controller/ContentController.java
@@ -10,7 +10,7 @@ public class ContentController {
     public String login(){
         return "login";
     }
-    @GetMapping("req/signup")
+    @GetMapping("/req/signup")
     public String registration(){
         return "signup";
     }


### PR DESCRIPTION
## Summary
- add leading slash to `ContentController` signup endpoint

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6845049bd4e8832a97792e7d9cc5c5a9