### PR TITLE
Fix typo in signup comments

### DIFF
--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -64,9 +64,9 @@
           body: jsonData
         })
         .then(response =>{
-          //alert('succesfull');
+          //alert('successful');
           //if(response.status == 200){
-            //alert('succesfull');
+            //alert('successful');
           //xs}
         })
       }


### PR DESCRIPTION
## Summary
- correct the 'succesfull' typo in `signup.html`
- verify no other files contain the typo

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684504af8a94832a9c113308a3df7be0