### PR TITLE
Add MockMvc test for signup page

### DIFF
--- a/src/test/java/com/example/demo/ContentControllerTest.java
+++ b/src/test/java/com/example/demo/ContentControllerTest.java
@@ -1,0 +1,27 @@
+package com.example.demo;
+
+import com.example.demo.controller.ContentController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@WebMvcTest(ContentController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ContentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void signupPageReturnsView() throws Exception {
+        mockMvc.perform(get("/req/signup"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("signup"));
+    }
+}


### PR DESCRIPTION
## Summary
- create `ContentControllerTest` using MockMvc
- confirm `spring-boot-starter-test` already present

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_684504b7ec50832a935f5bcdbfa01e8d